### PR TITLE
Add support for restoring data from var_dump() results

### DIFF
--- a/src/Lang/Record/LanguageRecord.php
+++ b/src/Lang/Record/LanguageRecord.php
@@ -89,4 +89,16 @@ class LanguageRecord implements IResourceRecord
         $out = null;
         return false;
     }
+    
+    /**
+     * Restore data from a var_dump() result.
+     */
+    public static function __set_state(array $state): object
+    {
+        $pThis = (new \ReflectionClass(self::class))->newInstanceWithoutConstructor();
+        
+        $pThis->entries = $state["entries"];
+        
+        return $pThis;
+    }
 }

--- a/src/Lang/Record/RecordEntries.php
+++ b/src/Lang/Record/RecordEntries.php
@@ -58,4 +58,19 @@ class RecordEntries extends stdClass implements ArrayAccess
     {
         return isset($this->{$this->iterationPosition});
     }
+    
+    /**
+     * Restore data from a var_dump() result.
+     */
+    public static function __set_state(array $state): object
+    {
+        $pThis = new self();
+        
+        foreach ($state as $key => $value)
+        {
+            $pThis->{$key} = $value;
+        }
+        
+        return $pThis;
+    }
 }


### PR DESCRIPTION
These objects are very likely to be cached, and this change aids in restoring from cache.